### PR TITLE
[Feature] Implement Wavy EditText using Compose

### DIFF
--- a/wavy-compose/build.gradle
+++ b/wavy-compose/build.gradle
@@ -53,4 +53,6 @@ dependencies {
 
     implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    implementation project(path: ':wavy')
 }

--- a/wavy-compose/src/main/java/wavy/EditText.kt
+++ b/wavy-compose/src/main/java/wavy/EditText.kt
@@ -1,0 +1,20 @@
+package wavy
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EditText (
+    text: String,
+    modifier: Modifier,
+    onTextChanged: (String) -> Unit,
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = text,
+        onValueChange = onTextChanged,
+        decorationBox = { innerTextField -> innerTextField() }
+    )
+}

--- a/wavy-compose/src/main/java/wavy/EditText.kt
+++ b/wavy-compose/src/main/java/wavy/EditText.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-fun EditText (
+fun ComposeEditText (
     text: String,
     modifier: Modifier,
     onTextChanged: (String) -> Unit,

--- a/wavy-compose/src/main/java/wavy/EditTextAnimateMovement.kt
+++ b/wavy-compose/src/main/java/wavy/EditTextAnimateMovement.kt
@@ -1,0 +1,111 @@
+package wavy
+
+import android.view.MotionEvent
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.focusable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.basicWavyMovement(
+    scope: CoroutineScope,
+    focusRequester: FocusRequester,
+    animationSpec: AnimationSpec<Float> = tween(1000),
+    accentLineColor: Color = Color(0xFFEF00FF),
+    accentLineStrokeWidth: Dp = 1.dp,
+    accentLineYPositionFromBottom: Dp = 1.dp,
+    defaultLineColor: Color = Color(0xFF000000),
+    defaultLineStrokeWidth: Dp = 1.dp,
+    defaultLineYPositionFromBottom: Dp = 1.dp
+ ): Modifier = composed {
+
+    var underLineWidth by remember { mutableStateOf(0f) }
+
+    var underLinePivotXPosition by remember { mutableStateOf(0f) }
+
+    var underLineState by remember {
+        mutableStateOf(
+            OriginalUnderlineLength(
+                left = underLineWidth / 2,
+                right = underLineWidth / 2
+            )
+        )
+    }
+
+    var underLineAnimationEnabled by remember { mutableStateOf(false) }
+
+    val underLineAnimation by animateFloatAsState(
+        animationSpec = animationSpec,
+        targetValue = if(underLineAnimationEnabled) 0f else 1f
+    )
+
+    with(scope) {
+        this@composed
+            .focusRequester(focusRequester = focusRequester)
+            .pointerInteropFilter { motionEvent ->
+                when(motionEvent.action) {
+                    MotionEvent.ACTION_DOWN -> {
+
+                        underLinePivotXPosition = motionEvent.x
+                        underLineState.apply {
+                            left = underLinePivotXPosition
+                            right = underLineWidth - underLinePivotXPosition
+                        }
+
+                        focusRequester.requestFocus()
+
+                        false
+                    }
+
+                    else -> true
+                }
+            }
+            .onFocusChanged {  focusState ->
+                underLineAnimationEnabled = !focusState.hasFocus
+            }
+            .focusable()
+            .drawWithContent {
+
+                drawContent()
+
+                underLineWidth = size.width
+
+                drawAccentLine(
+                    contentDrawScope = this,
+                    underLinePivotXPosition =  underLinePivotXPosition,
+                    originalUnderLineLength = underLineState,
+                    underLineAnimation = underLineAnimation,
+                    accentLineColor = accentLineColor,
+                    accentLineStrokeWidth = accentLineStrokeWidth,
+                    accentLineYPositionFromBottom = accentLineYPositionFromBottom
+                )
+
+                drawDefaultLine(
+                    contentDrawScope = this,
+                    underLinePivotXPosition =  underLinePivotXPosition,
+                    originalUnderLineLength = underLineState,
+                    underLineAnimation = underLineAnimation,
+                    defaultLineColor = defaultLineColor,
+                    defaultLineStrokeWidth = defaultLineStrokeWidth,
+                    defaultLineYPositionFromBottom = defaultLineYPositionFromBottom
+                )
+            }
+    }
+
+}

--- a/wavy-compose/src/main/java/wavy/UnderLineExt.kt
+++ b/wavy-compose/src/main/java/wavy/UnderLineExt.kt
@@ -1,0 +1,83 @@
+package wavy
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+fun drawAccentLine(
+    contentDrawScope: ContentDrawScope,
+    underLinePivotXPosition: Float,
+    originalUnderLineLength: OriginalUnderlineLength,
+    underLineAnimation: Float,
+    accentLineColor: Color,
+    accentLineStrokeWidth: Dp,
+    accentLineYPositionFromBottom: Dp
+) {
+    contentDrawScope.apply {
+        drawLine(
+            color = accentLineColor,
+            start = Offset(
+                x = underLinePivotXPosition,
+                y = size.height - accentLineYPositionFromBottom.toPx(),
+            ),
+            end = Offset(
+                x = underLinePivotXPosition - originalUnderLineLength.left * underLineAnimation,
+                y = size.height - accentLineYPositionFromBottom.toPx()
+            ),
+            strokeWidth = accentLineStrokeWidth.toPx(),
+        )
+
+        drawLine(
+            color = accentLineColor,
+            start = Offset(
+                x = underLinePivotXPosition,
+                y = size.height - accentLineYPositionFromBottom.toPx(),
+            ),
+            end = Offset(
+                x = underLinePivotXPosition + originalUnderLineLength.right * underLineAnimation,
+                y = size.height - accentLineYPositionFromBottom.toPx()
+            ),
+            strokeWidth = accentLineStrokeWidth.toPx(),
+        )
+    }
+}
+
+fun drawDefaultLine(
+    contentDrawScope: ContentDrawScope,
+    underLinePivotXPosition: Float,
+    originalUnderLineLength: OriginalUnderlineLength,
+    underLineAnimation: Float,
+    defaultLineColor: Color,
+    defaultLineStrokeWidth: Dp,
+    defaultLineYPositionFromBottom: Dp
+) {
+    contentDrawScope.apply {
+        drawLine(
+            color = defaultLineColor,
+            start = Offset(
+                x = 0f,
+                y = size.height - defaultLineYPositionFromBottom.toPx(),
+            ),
+            end = Offset(
+                x = originalUnderLineLength.left * (1f - underLineAnimation),
+                y = size.height - defaultLineYPositionFromBottom.toPx()
+            ),
+            strokeWidth = defaultLineStrokeWidth.toPx(),
+        )
+
+        drawLine(
+            color = defaultLineColor,
+            start = Offset(
+                x = underLinePivotXPosition + originalUnderLineLength.right * underLineAnimation,
+                y = size.height - defaultLineYPositionFromBottom.toPx(),
+            ),
+            end = Offset(
+                x = size.width,
+                y = size.height - defaultLineYPositionFromBottom.toPx()
+            ),
+            strokeWidth = defaultLineStrokeWidth.toPx(),
+        )
+    }
+}

--- a/wavy-sample/build.gradle
+++ b/wavy-sample/build.gradle
@@ -29,11 +29,32 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.6"
+    }
 }
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
+
+    def composeBom = platform('androidx.compose:compose-bom:2023.04.01')
+    implementation composeBom
+    androidTestImplementation composeBom
+
+    implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.activity:activity-compose:1.7.2'
+
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
     implementation project(path: ':wavy')
+    implementation project(path: ':wavy-compose')
+
 }

--- a/wavy-sample/src/main/AndroidManifest.xml
+++ b/wavy-sample/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:theme="@style/Theme.Sample">
 
         <activity
-            android:name=".MainActivity"
+            android:name=".ComposeMainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/wavy-sample/src/main/java/wavy/sample/ComposeMainActivity.kt
+++ b/wavy-sample/src/main/java/wavy/sample/ComposeMainActivity.kt
@@ -1,0 +1,67 @@
+package wavy.sample
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.Role.Companion.Button
+import androidx.compose.ui.unit.dp
+import wavy.ComposeEditText
+import wavy.basicWavyMovement
+
+class ComposeMainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+
+            var text by remember { mutableStateOf("") }
+
+            val scope = rememberCoroutineScope()
+
+            val focusManager = LocalFocusManager.current
+
+            val focusRequester by remember { mutableStateOf(FocusRequester()) }
+
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ComposeEditText(
+                    text = text,
+                    modifier = Modifier
+                        .padding(top = 200.dp)
+                        .fillMaxWidth()
+                        .basicWavyMovement(
+                            focusRequester = focusRequester,
+                            scope = scope,
+                            animationSpec = tween(1000)
+                        ),
+                    onTextChanged = { text = it }
+                )
+
+                Button(
+                    modifier = Modifier.padding(top = 50.dp),
+                    onClick = { focusManager.clearFocus() })
+                {
+                    Text(text = "reverse")
+                }
+            }
+
+            }
+        }
+
+}


### PR DESCRIPTION
- Implement **Wavy EditText using Compose** on wavy-compose module
- Implement **Wavy EditText Example** on wavy-sample module

(I think we need wavy-compose-sample module to show wavy-compose sample activity)
(I temporarily named EditText ComposeEditText. Because there is a conflict with the existing wavy.)